### PR TITLE
feat: generalize luminance weights and alpha threshold

### DIFF
--- a/src/image_processor.cpp
+++ b/src/image_processor.cpp
@@ -106,7 +106,7 @@ ImageFormat ImageProcessor::detect_format(const std::string& path) {
 
 uint8_t ImageProcessor::calculate_luminance(uint8_t r, uint8_t g, uint8_t b) {
     // L = 0.299*R + 0.587*G + 0.114*B
-    float luma = 0.299f * r + 0.587f * g + 0.114f * b;
+    float luma = LUMA_COEF_R * r + LUMA_COEF_G * g + LUMA_COEF_B * b;
     return static_cast<uint8_t>(std::clamp(luma, 0.0f, 255.0f));
 }
 

--- a/src/image_processor.h
+++ b/src/image_processor.h
@@ -7,6 +7,14 @@
 
 namespace fbiu {
 
+// ITU-R BT.601 standard luminance coefficients
+constexpr float LUMA_COEF_R = 0.299f;
+constexpr float LUMA_COEF_G = 0.587f;
+constexpr float LUMA_COEF_B = 0.114f;
+
+// Default threshold for luma-to-alpha conversion
+constexpr uint8_t DEFAULT_LUMA_THRESHOLD = 200;
+
 enum class ImageFormat {
     PNG,
     TIFF,


### PR DESCRIPTION
This allows users to customize the luma calculation and transparency mapping instead of using hardcoded values.

Closes #1