### PR TITLE
feat: add custom luminance coefficients and GUI controls#4

### DIFF
--- a/include/main_window.h
+++ b/include/main_window.h
@@ -13,6 +13,9 @@
 #include <QMenu>
 #include <QAction>
 #include <QMimeData>
+#include <QGroupBox>
+#include <QSlider>
+#include <QVBoxLayout>
 #include "image_processor.h"
 
 namespace fbiu {
@@ -39,11 +42,23 @@ private slots:
     void handle_dropped_paths(const QStringList& paths);
     void showAboutQt();
     
+    // Custom parameter slots
+    void threshold_slider_changed(int value);
+    void coef_r_slider_changed(int value);
+    void coef_g_slider_changed(int value);
+    void coef_b_slider_changed(int value);
+    
 private:
     void setup_ui();
     void setup_connections();
     void switch_language(const QString& lang);
     void retranslate_ui();
+    
+    // Custom parameter functions
+    void setup_custom_param_ui(QVBoxLayout* main_layout);
+    void update_custom_param_visibility();
+    void save_custom_params();
+    void load_custom_params();
     
     // UI components
     QPushButton* input_button;
@@ -65,6 +80,17 @@ private:
     // Menu
     QMenu* helpMenu;
     QAction* aboutQtAction;
+    
+    // Custom parameter UI elements
+    QGroupBox* custom_params_group;
+    QSlider* threshold_slider;
+    QSlider* coef_r_slider;
+    QSlider* coef_g_slider;
+    QSlider* coef_b_slider;
+    QLabel* threshold_value_label;
+    QLabel* coef_r_value_label;
+    QLabel* coef_g_value_label;
+    QLabel* coef_b_value_label;
 
     // State
     QString input_folder;
@@ -72,6 +98,7 @@ private:
     QString output_folder;
     fbiu::ProcessFunction current_function;
     bool is_single_file_mode = false;
+    fbiu::CustomLumaParams current_custom_params;
     
     // Translation
     QTranslator translator;

--- a/src/image_processor.h
+++ b/src/image_processor.h
@@ -15,6 +15,14 @@ constexpr float LUMA_COEF_B = 0.114f;
 // Default threshold for luma-to-alpha conversion
 constexpr uint8_t DEFAULT_LUMA_THRESHOLD = 200;
 
+// Custom luminance parameters
+struct CustomLumaParams {
+    float coef_r = LUMA_COEF_R;
+    float coef_g = LUMA_COEF_G;
+    float coef_b = LUMA_COEF_B;
+    uint8_t threshold = DEFAULT_LUMA_THRESHOLD;
+};
+
 enum class ImageFormat {
     PNG,
     TIFF,
@@ -25,8 +33,9 @@ enum class ImageFormat {
 };
 
 enum class ProcessFunction {
-    LUMA_TO_ALPHA,    // Luminance → Transparency (alpha) mask
-    CONVERT_TO_PNG     // Simple format conversion to PNG
+    LUMA_TO_ALPHA,        // Luminance → Transparency (alpha) mask
+    LUMA_TO_ALPHA_CUSTOM, // Custom luminance → Transparency with adjustable parameters
+    CONVERT_TO_PNG        // Simple format conversion to PNG
 };
 
 struct ImageData {
@@ -56,7 +65,8 @@ public:
     static ImageFormat detect_format(const std::string& path);
     
     // Process functions
-    static ImageData luma_to_alpha(const ImageData& input, uint8_t threshold = 200);
+    static ImageData luma_to_alpha(const ImageData& input, uint8_t threshold = DEFAULT_LUMA_THRESHOLD);
+    static ImageData luma_to_alpha_custom(const ImageData& input, const CustomLumaParams& params);
     static ImageData convert_to_png(const ImageData& input);
     
     // Apply processing function
@@ -68,7 +78,8 @@ public:
         std::string output_dir;
         ProcessFunction function = ProcessFunction::LUMA_TO_ALPHA;
         int num_threads = 0;  // 0 = auto-detect
-        uint8_t luma_threshold = 200;  // Threshold for preserving original colors (0-255)
+        uint8_t luma_threshold = DEFAULT_LUMA_THRESHOLD;  // Threshold for standard luma_to_alpha
+        CustomLumaParams custom_params;  // Parameters for LUMA_TO_ALPHA_CUSTOM
         std::function<void(int, int, const std::string&)> progress_callback;
     };
     
@@ -77,6 +88,10 @@ public:
 private:
     // Luminance calculation: L = 0.299*R + 0.587*G + 0.114*B
     static uint8_t calculate_luminance(uint8_t r, uint8_t g, uint8_t b);
+    
+    // Custom luminance calculation with custom coefficients
+    static uint8_t calculate_luminance_custom(uint8_t r, uint8_t g, uint8_t b, 
+                                             float coef_r, float coef_g, float coef_b);
 };
 
 } // namespace fbiu


### PR DESCRIPTION
Closes #4

## Summary
Enabled users to adjust RGB coefficients and threshold for luminance-to-alpha conversion.

## Changes
- Added custom calculation logic to `ImageProcessor`.
- Added sliders (Threshold, R, G, B) to the GUI.
- Implemented real-time preview.