### PR TITLE
build: remove console window from gui application on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,11 @@ if(BUILD_GUI)
         )
     endforeach()
     
+    if(WIN32)
+    add_executable(fbiu_gui WIN32 ${GUI_SOURCES} ${QM_FILES})
+    else()
     add_executable(fbiu_gui ${GUI_SOURCES} ${QM_FILES})
+    endif()
     target_link_libraries(fbiu_gui PRIVATE 
         image_core
         Qt6::Core


### PR DESCRIPTION
Add WIN32 option to fbiu_gui executable target in CMakeLists.txt. This configures the application to use the Windows GUI subsystem instead of the console subsystem, preventing an unwanted console window from appearing when launching the GUI.

Resolves #9
Resolves #6